### PR TITLE
ixp4xx-npe: fix COMPATIBLE_MACHINE

### DIFF
--- a/recipes-kernel/ixp4xx/ixp4xx-npe_2.4.bb
+++ b/recipes-kernel/ixp4xx/ixp4xx-npe_2.4.bb
@@ -22,7 +22,7 @@ SRC_URI[npelib.sha256sum] = "f764d0554e236357fc55d128a012cb6ac2ceb638023f4af88c8
 
 S = "${WORKDIR}/ixp400_xscale_sw/src/npeDl"
 
-COMPATIBLE_MACHINE = "(nslu2|ixp4xx|kixrp435)"
+COMPATIBLE_MACHINE = "(nslu2|ixp4xx|kixrp435)*"
 
 do_compile_class-target () {
 	IxNpeMicrocode-${PV} -be


### PR DESCRIPTION
ERROR: Nothing PROVIDES 'ixp4xx-npe-native' (but /build/jenkins/angstrom-v2014.06/machine/nslu2be/sources/meta-nslu2/recipes-kernel/ixp4xx/ixp4xx-npe_2.4.bb DEPENDS on or otherwise requires it)
ERROR: ixp4xx-npe-native was skipped: incompatible with machine nslu2be (not in COMPATIBLE_MACHINE)
NOTE: Runtime target 'ixp4xx-npe' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['ixp4xx-npe','ixp4xx-npe-native']
NOTE: Runtime target 'angstrom-packagegroup-boot' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['angstrom-packagegroup-boot', 'packagegroup-boot', 'ixp4xx-npe', 'ixp4xx-npe-native']
ERROR: Required build target 'systemd-image' has no buildable providers.
Missing or unbuildable dependency chain was: ['systemd-image', 'angstrom-packagegroup-boot', 'packagegroup-boot', 'ixp4xx-npe','ixp4xx-npe-native']

Signed-off-by: Koen Kooi koen@dominion.thruhere.net
